### PR TITLE
Debug Unsplash search script errors

### DIFF
--- a/dev-tools/unsplash-search.js
+++ b/dev-tools/unsplash-search.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { createApi } from 'unsplash-js';
+import { ProxyAgent } from 'undici';
 import { config } from 'dotenv';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
@@ -21,7 +22,7 @@ if (!process.env.UNSPLASH_ACCESS_KEY) {
 class UnsplashImageSearch {
   constructor() {
     this.accessKey = process.env.UNSPLASH_ACCESS_KEY;
-    
+
     if (!this.accessKey) {
       console.error('❌ Error: UNSPLASH_ACCESS_KEY not found in .env.local');
       console.error('📝 Please create .env.local file with your Unsplash API key');
@@ -29,8 +30,23 @@ class UnsplashImageSearch {
       process.exit(1);
     }
 
+    // プロキシ設定を取得
+    const proxyUrl = process.env.HTTPS_PROXY || process.env.https_proxy ||
+                     process.env.HTTP_PROXY || process.env.http_proxy;
+
+    // カスタムfetchを設定（プロキシサポート付き）
+    const customFetch = proxyUrl
+      ? (url, options) => {
+          return fetch(url, {
+            ...options,
+            dispatcher: new ProxyAgent(proxyUrl)
+          });
+        }
+      : undefined;
+
     this.unsplash = createApi({
       accessKey: this.accessKey,
+      fetch: customFetch,
     });
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "dotenv": "^16.4.5",
+        "undici": "^7.16.0",
         "unsplash-js": "^7.0.19"
       },
       "engines": {
@@ -26,6 +27,15 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.16.0.tgz",
+      "integrity": "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/unsplash-js": {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
     "search": "node dev-tools/unsplash-search.js"
   },
   "dependencies": {
-    "unsplash-js": "^7.0.19",
-    "dotenv": "^16.4.5"
+    "dotenv": "^16.4.5",
+    "undici": "^7.16.0",
+    "unsplash-js": "^7.0.19"
   },
   "keywords": [
     "webpage",


### PR DESCRIPTION
問題:
- Node.jsのネイティブfetch APIがHTTPS_PROXY環境変数を認識せず
- DNS解決が失敗し「fetch failed: getaddrinfo EAI_AGAIN」エラーが発生
- curlは動作するがNode.jsスクリプトは失敗していた

解決策:
- undiciパッケージのProxyAgentを導入
- 環境変数からプロキシURLを取得してカスタムfetchを実装
- unsplash-jsのcreateApi()にカスタムfetchを渡すように修正

変更内容:
- dev-tools/unsplash-search.js: ProxyAgentサポートを追加
- package.json: undici依存関係を追加